### PR TITLE
Adding $BASEDIR to the db file path for OS X

### DIFF
--- a/humpty.sh
+++ b/humpty.sh
@@ -58,7 +58,7 @@ function dump_db {
             # couldn't pull the file; stream its contents instead, removing any end-of-line character returns
             if [ $(uname) == 'Darwin' ]; then
                 adb shell run-as $pkg cat /data/data/$pkg/$filename > $BASEDIR/dumps/$pkg/$filename
-                perl -pi -e 's/\r\n/\n/g' dumps/$pkg/$filename
+                perl -pi -e 's/\r\n/\n/g' $BASEDIR/dumps/$pkg/$filename
             else
                 adb shell run-as $pkg cat /data/data/$pkg/$filename | sed 's/\r$//' > $BASEDIR/dumps/$pkg/$filename
             fi


### PR DESCRIPTION
When the $BASEDIR var was added it was not added in the OS X flow, which resulted in a malformed database.
